### PR TITLE
The container image is wrong in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Podman Build and Push Action
-        uses: frozen-tapestry/podman-build-push-action@v1
+        uses: Frozen-Tapestry/container-action@v1
         with:
           login_registry: ghcr.io
           login_username: ${{ secrets.REGISTRY_USERNAME }}


### PR DESCRIPTION
The name of the container image that is given in the documentation of the repository is wrong. 

If you use that name, you'll get this error:
> Error: Missing download info for frozen-tapestry/podman-build-push-action@v1

An example of the issue is found [here](https://github.com/felipet/lacoctelera_backend/actions/runs/13584103800).

If you replace that identifier by `uses: Frozen-Tapestry/container-action@v1` it works, as shown [here](https://github.com/felipet/lacoctelera_backend/actions/runs/13584198263/job/37975555587).