### PR TITLE
Fix for pushing all the tags of an image to GitHub's registry

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -96,10 +96,13 @@ if [[ -n "$PUSH" && "$PUSH" == "true" ]]; then
   TAGS=$(generate_args "$ACTION_TAGS" "")
   echo "Tags: ${TAGS[@]}"
 
-  build_cmd=(podman push
-    --storage-driver=overlay
-    --authfile="$REGISTRY_AUTH_FILE"
-    $TAGS
-  )
-  run_cmd "${build_cmd[@]}"
+  for tag in $TAGS
+  do
+    build_cmd=(podman push
+      --storage-driver=overlay
+      --authfile="$REGISTRY_AUTH_FILE"
+      $tag
+    )
+    run_cmd "${build_cmd[@]}"
+  done
 fi


### PR DESCRIPTION
# Description of the issue that motivated the fix

The current command to push images to a registry seems to have a bug when pushing an image to GitHub's registry.

The issue was detected here: [Podman build log](https://github.com/felipet/shortbot/actions/runs/16072885466/job/45368124239)

This is an extract:
```
Tags: ghcr.io/felipet/shortbot:0.4.0
ghcr.io/felipet/shortbot:latest
Running: podman	push	--storage-driver=overlay	--authfile=/home/podman/auth/auth.json	ghcr.io/felipet/shortbot:0.4.0	ghcr.io/felipet/shortbot:latest	
Getting image source signatures
Copying blob sha256:7e79842d6d3486d0ce9323974883f8417cdaf227b5c25602bf3778fd037e35f0
Copying blob sha256:1287fbecdfcce6ee8cf2436e5b9e9d86a4648db2d91080377d499737f1b307f3
Copying blob sha256:f51451bcf5570fd7dff24ceb7009875a4ed843b8db241aabff2990fabef72f7d
Copying blob sha256:d7827ff82d1d9df3bffbd2de628559c3d516daa959f6350696ca28b7f199a866
Copying blob sha256:5061153b5a65a401c6886f55858807e2a330919d4d4f3ca5fc875782ca2cee0c
Copying blob sha256:d67313a3a714ea78da7e2fd8285b9235160c989f4c3b2c437813c7a5906bc414
Copying config sha256:60adf1d4b382170363c9c5c2324b19aa5c415419c440e11c3ff40e165f9c01ab
Writing manifest to image destination
Complete code: 0
```
As it can be seen, the image is tagged properly with two tags: `latest` and `0.4.0`. Both tags are passed to `podman push` but when you check the result in the registry, only the tag `latest` is shown. According to `podman push` docs, the command pushes a single image, so my gut feeling is that it takes whatever is the latest passed argument, and pushes it.

# Fix

The fix is simple: adds a `for` loop that iterates over all the tags of the image, and runs `podman push`. It actually doesn't push the image many times, as it detects that the image's signature is the same after the first push, so the successive pushes only add tags to the image in the registry, which is efficient and neat.
